### PR TITLE
RAINCATCH-1118v1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -90,14 +90,31 @@ Build the example located in the _upstream-1_ folder:
     git commit -a -m"Pages update"
     git push origin +gh-pages
     
-=== Creating References to Anchors
+=== Creating Anchors and xrefs
 
+==== Dynamic Anchor and Dynamic xref
 An anchor (for example: [[Testing the App]]) cannot appear more than once in an *.adoc* file.
 As Modular Doc files are regularly reused in the same *.adoc* file, this results in a build error.
 See link:http://asciidoctor.org/docs/user-manual/#include-multiple[Including Multiple Anchors] to negate this issue.
 
 To best understand the information above, see the example located in the repo.
 
+==== Dynamic Anchors and Hard-Coded xref
+
+There are occasions when a dynamic xref (xref:ref-logging-{chapter}) will have to be hard coded (xref:ref-logging-user-_story-a_)
+
+This happens when:
+ * the value inserted at build time for "{chapter}" is set in *User Story A* - the value for "{chapter}" being (:chapter: user-story-_a_)
+ * *User Story B* includes the module which contains the anchor "[id='ref-logging-{chapter}']" that the xref points to, and the "{chapter}" value being (:chapter: user-story-_b_)
+ * when the book is built, "xref:ref-logging-user-story-_a_" however "xref:ref-logging-user-story-_b_" does
+ 
+The solution is a hard-coded xref:
+ * for the "xref:ref-logging-{chapter}" being set in *User Story A*
+ * hard code it as "xref:ref-logging-user-story-_b_"
+ * so when the book is built, "xref:ref-logging-user-story-_b_" is a valid anchor
+ 
+ NOTE: If an xref is used to point to an anchor in a module, and the module itself is not built as part of the build - this will cause an error.
+ 
 === Writing a User Story, *not* a Feature
 
 IMPORTANT: It is vital that content is created with a User Story in mind

--- a/docs/workforce-management-framework/rhmap/introducing-the-features-of-raincatcher.adoc
+++ b/docs/workforce-management-framework/rhmap/introducing-the-features-of-raincatcher.adoc
@@ -1,1 +1,0 @@
-../upstream-1/introducing-the-features-of-raincatcher.adoc

--- a/docs/workforce-management-framework/rhmap/master.adoc
+++ b/docs/workforce-management-framework/rhmap/master.adoc
@@ -1,11 +1,9 @@
 include::topics/shared/attributes.adoc[]
 
 = {WFM-RC-NameLong}
-Reference Documentation for {WFM-RC-NameLong}
 
 [[introducing-raincatcher]]
 == Introducing {WFM-RC-NameLong}
-include::introducing-the-features-of-raincatcher.adoc[leveloffset=+2]
 
 [[preparing-the-local-development-environment]]
 == Preparing the Local Development Environment
@@ -25,6 +23,9 @@ include::using-wfm-logger-and-setting-a-logging-level.adoc[leveloffset=+2]
 
 [[raincatcher-modules-reference]]
 == {WFM-RC-NameShort} Modules Reference
+
+[[raincatcher-appendix]]
+== {WFM-RC-NameShort} Appendix
 
 // **********************************
 // * Appendix: Revision Information *

--- a/docs/workforce-management-framework/rhmap/using-wfm-logger-and-setting-a-logging-level.adoc
+++ b/docs/workforce-management-framework/rhmap/using-wfm-logger-and-setting-a-logging-level.adoc
@@ -1,1 +1,1 @@
-../upstream-1/using-wfm-logger-and-setting-a-logging-level.adoc
+../upstream-1/using-raincatcher-logger-and-setting-a-logging-level.adoc

--- a/docs/workforce-management-framework/topics/con-auth-demo-module.adoc
+++ b/docs/workforce-management-framework/topics/con-auth-demo-module.adoc
@@ -1,0 +1,8 @@
+[id='con-auth-demo-module-{chapter}']
+=  Auth-Demo Module Details
+
+The name of this module is  `wfm-auth-demo`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-auth-keycloak-module.adoc
+++ b/docs/workforce-management-framework/topics/con-auth-keycloak-module.adoc
@@ -1,0 +1,8 @@
+[id='con-auth-keycloak-module-{chapter}']
+=  Auth-Keycloak Module Details
+
+The name of this module is  `wfm-auth-keycloak`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-logging.adoc
+++ b/docs/workforce-management-framework/topics/con-logging.adoc
@@ -1,4 +1,4 @@
-[id='logging-module-{chapter}']
+[id='con-logging-{chapter}']
 = Logging Module
 
 The {WFM-RC-NameLong} Logger Module is a logging facade for node.js based applications and it is used by all {WFM-RC-NameLong} modules.

--- a/docs/workforce-management-framework/topics/con-module-structures-and-relationships.adoc
+++ b/docs/workforce-management-framework/topics/con-module-structures-and-relationships.adoc
@@ -1,0 +1,7 @@
+[id='con-module-structures-and-relationships-{chapter}']
+= Module Structures and Relationships
+
+<**TODO**> Add Concept only info here. No details, just provide user with _context_. If they want to know more, let them choose to click on the link to the reference material.
+
+// Hard coded xref was required
+For more information, see xref:ref-module-structures-and-relationships-raincatcher-reference-material[Module Structure and Relationship Reference Information].

--- a/docs/workforce-management-framework/topics/con-mongoose-module.adoc
+++ b/docs/workforce-management-framework/topics/con-mongoose-module.adoc
@@ -1,0 +1,8 @@
+[id='con-mongoose-module-{chapter}']
+=  Mongoose Module Details
+
+The name of this module is  `wfm-mongoose-store`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-raincatcher-demo.adoc
+++ b/docs/workforce-management-framework/topics/con-raincatcher-demo.adoc
@@ -1,0 +1,7 @@
+[id='con-raincatcher-demo-{chapter}']
+=  {WFM-RC-NameLong} Demo Application
+
+{WFM-RC-NameLong} contains a demo application which is used to demonstrate various {WFM-RC-NameLong} features.
+
+// Hard coded xref was required
+For more information, see xref:ref-raincatcher-demo-raincatcher-reference-material[{WFM-RC-NameLong} Demo Application Reference Information].

--- a/docs/workforce-management-framework/topics/con-raincatcher-old-and-new.adoc
+++ b/docs/workforce-management-framework/topics/con-raincatcher-old-and-new.adoc
@@ -1,0 +1,9 @@
+[id='con-raincatcher-old-and-new-{chapter}']
+= Differentiating between {WFM-RC-NameLong} 'Next' and 'Beta'
+
+{WFM-RC-NameLong} Beta is the older version of the {WFM-RC-NameLong} framework.
+
+{WFM-RC-NameLong} Next is the new version of the {WFM-RC-NameLong} framework.
+
+// Hard coded xref was required
+For more information, see xref:ref-raincatcher-new-and-old-raincatcher-reference-material[{WFM-RC-NameLong} 'Next' and 'Beta' Reference Information].

--- a/docs/workforce-management-framework/topics/con-raincatcher-overview.adoc
+++ b/docs/workforce-management-framework/topics/con-raincatcher-overview.adoc
@@ -1,0 +1,14 @@
+[id='con-raincatcher-overview-{chapter}']
+= {WFM-RC-NameLong} Overview
+
+{WFM-RC-NameLong} is a software framework and is made up with varying node.js modules which are written in TypeScript.
+These modules are packaged and distributed as part of the {WFM-RC-NameLong} solution.
+The primary use of the {WFM-RC-NameLong} solution is to provide a Workforce Management Oriented framework for Workforce Management applications.
+
+The {WFM-RC-NameLong} solution comprises of two fully independent frameworks:
+
+ * Workflow Management Framework
+ * Security Framework
+
+// Hard coded xref was required
+For more information, see xref:ref-workflow-management-framework-raincatcher-reference-material[Workflow Management Framework Reference Information].

--- a/docs/workforce-management-framework/topics/con-result-module.adoc
+++ b/docs/workforce-management-framework/topics/con-result-module.adoc
@@ -1,0 +1,8 @@
+[id='con-result-module-{chapter}']
+=  Result Module Details
+
+The name of this module is  `wfm-result`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-sync-module.adoc
+++ b/docs/workforce-management-framework/topics/con-sync-module.adoc
@@ -1,0 +1,8 @@
+[id='con-sync-module-{chapter}']
+=  Sync Module Details
+
+The name of this module is  `wfm-sync`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-user-no-auth-module.adoc
+++ b/docs/workforce-management-framework/topics/con-user-no-auth-module.adoc
@@ -1,0 +1,8 @@
+[id='con-user-module-{chapter}']
+=  User (No Auth) Module Details
+
+The name of this module is  `wfm-user`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-workflow-module.adoc
+++ b/docs/workforce-management-framework/topics/con-workflow-module.adoc
@@ -1,0 +1,8 @@
+[id='con-workflow-module-{chapter}']
+=  Workflow Module Details
+
+The name of this module is  `wfm-workflow`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/con-workorder-module.adoc
+++ b/docs/workforce-management-framework/topics/con-workorder-module.adoc
@@ -1,0 +1,8 @@
+[id='con-workorder-module-{chapter}']
+=  Workorder Module Details
+
+The name of this module is  `wfm-workorder`.
+
+(PRD-104.2)
+<**TODO**>
+This module should be explained from a high level and its primary function defined.

--- a/docs/workforce-management-framework/topics/pro-importing-the-bunyan-logging-module.adoc
+++ b/docs/workforce-management-framework/topics/pro-importing-the-bunyan-logging-module.adoc
@@ -1,4 +1,4 @@
-[[importing-the-bunyan-logging-module]]
+[id='pro-importing-the-bunyan-logging-module-{chapter}']
 = Importing the Bunyan Logging Module
 
 To incorporate the Bunyan logging into a project, the {WFM-RC-NameShort} Logging Module is imported and then the Bunyan Logging Module is initialized.
@@ -29,4 +29,4 @@ logger.info('This log will render with BunyanLogger');
 
 .Related Information
 
-* For more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]
+* For more information, see xref:ref-logging-{chapter}[Logging Reference Information]

--- a/docs/workforce-management-framework/topics/pro-importing-the-console-logging-module.adoc
+++ b/docs/workforce-management-framework/topics/pro-importing-the-console-logging-module.adoc
@@ -1,4 +1,4 @@
-[[importing-the-console-logging-module]]
+[id='pro-importing-the-console-logging-module-{chapter}']
 = Importing the Console Logging Module
 
 To incorporate the Console logging into a project, the {WFM-RC-NameShort} Logging Module is imported and then the Console Logging Module is initialized.
@@ -30,4 +30,4 @@ logger.info('This log will render with ConsoleLogger');
 
 .Related Information
 
-* For more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]
+* For more information, see xref:ref-logging-{chapter}[Logging Reference Information]

--- a/docs/workforce-management-framework/topics/pro-setting-the-bunyan-logging-level.adoc
+++ b/docs/workforce-management-framework/topics/pro-setting-the-bunyan-logging-level.adoc
@@ -1,11 +1,11 @@
-[[setting-the-bunyan-logging-level]]
+[id='pro-setting-the-bunyan-logging-level-{chapter}']
 = Setting the Bunyan Logging Level
 
-Determine the logging level you want (for more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]) and set the Bunyan logging level accordingly.
+Determine the logging level you want (for more information, see xref:ref-logging-{chapter}[Logging Reference Information]) and set the Bunyan logging level accordingly.
 
 .Prerequisites
 
-* The Bunyan Logging Module is imported. For more information, see xref:importing-the-bunyan-logging-module[Importing the Bunyan Logging Module]
+* The Bunyan Logging Module is imported. For more information, see xref:pro-importing-the-bunyan-logging-module-{chapter}[Importing the Bunyan Logging Module]
 
 .Procedure
 
@@ -21,4 +21,4 @@ setLogger(new ConsoleLogger(LogLevel.INFO));
 
 .Related Information
 
-* For more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]
+* For more information, see xref:ref-logging-{chapter}[Logging Reference Information]

--- a/docs/workforce-management-framework/topics/pro-setting-the-console-logging-level.adoc
+++ b/docs/workforce-management-framework/topics/pro-setting-the-console-logging-level.adoc
@@ -1,11 +1,11 @@
-[[setting-the-console-logging-level]]
+[id='pro-setting-the-console-logging-level-{chapter}']
 = Setting the Console Logging Level
 
-Determine the logging level you want (for more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]) and set the Console logging level accordingly.
+Determine the logging level you want (for more information, see xref:ref-logging-{chapter}[Logging Reference Information]) and set the Console logging level accordingly.
 
 .Prerequisites
 
-* The Console Logging Module is imported. For more information, see xref:importing-the-console-logging-module[Importing the Console Logging Module]
+* The Console Logging Module is imported. For more information, see xref:pro-importing-the-console-logging-module-{chapter}[Importing the Console Logging Module]
 
 .Procedure
 
@@ -21,4 +21,4 @@ setLogger(new BunyanLogger(LogLevel.INFO));
 
 .Related Information
 
-* For more information, see xref:logging-reference-template-and-guidelines-{chapter}[Logging Reference Template and Guidelines]
+* For more information, see xref:ref-logging-{chapter}[Logging Reference Information]

--- a/docs/workforce-management-framework/topics/ref-auth-demo-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-auth-demo-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-auth-demo-module-{chapter}']
+=  Auth-Demo Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-auth-keycloak-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-auth-keycloak-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-auth-keycloak-module-{chapter}']
+=  Auth-Keycloak Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-logging.adoc
+++ b/docs/workforce-management-framework/topics/ref-logging.adoc
@@ -1,5 +1,5 @@
-[id='logging-reference-template-and-guidelines-{chapter}']
-= Logging Reference Template and Guidelines
+[id='ref-logging-{chapter}']
+= Logging Reference Information
 
 This section describes:
 

--- a/docs/workforce-management-framework/topics/ref-module-structures-and-relationships.adoc
+++ b/docs/workforce-management-framework/topics/ref-module-structures-and-relationships.adoc
@@ -1,0 +1,40 @@
+[id='ref-module-structures-and-relationships-{chapter}']
+= Module Structure and Relationship Reference Information
+
+Raincatcher-AngularJS Application
+|===
+|raincatcher-demo-mobile | raincatcher-demo-portal | raincatcher-demo-cloud
+
+| Mobile application for WFM process users
+| Web application for WFM process administrators
+| Backend services for applications
+|===
+
+User Space Modules
+|===
+| vehicle-inspection-task
+|interface VehicleAssessment extends Task
+|===
+
+Raincatcher Core Modules and Interfaces
+|===
+|raincatcher-wfm |raincatcher-security
+
+|Workflow Management Framework, interface Task, interface Flow, interface Process
+|Security abstraction layer, class PassportAuth, Keycloak Middleware
+|===
+
+==  Module structure
+
+RainCatcher modules are written in link:http://typescriptlang.org[TypeScript].
+
+The main files are modules that by default export a class containing the main implementation for the module's intent,with a named export containing a public interface that should be depended upon, and reimplemented.
+
+```typescript
+import Implementation, { PublicInterface } from '@raincatcher/module';
+```
+== Default exports
+
+Each module exports by default an implementation and set of interfaces by name.
+Default implementation will usually implement most common use case for module.
+Along with the default export, all modules include a public interface definition that are depended upon by other RainCatcher modules instead of depending on the implementation itself.

--- a/docs/workforce-management-framework/topics/ref-mongoose-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-mongoose-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-mongoose-module-{chapter}']
+=  Mongoose Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-raincatcher-demo.adoc
+++ b/docs/workforce-management-framework/topics/ref-raincatcher-demo.adoc
@@ -1,0 +1,11 @@
+[id='ref-raincatcher-demo-{chapter}']
+= {WFM-RC-NameLong} Demo Application Reference Information
+
+The {WFM-RC-NameLong} demo is packaged as part of `raincatcher-core`.
+The {WFM-RC-NameLong} demo is called *Raincatcher-Angularjs*.
+
+The {WFM-RC-NameLong} demo contains:
+
+* Raincatcher-core contains non-production demo example that is used to showcase the modules functionality.
+* Raincatcher-angularjs has a set of example implementations for Workforce Management Solutions (Workorder, WorkorderResult)
+* Raincatcher-angularjs has a Website, Mobile and server demo applications serving as reference implementation for the framework.

--- a/docs/workforce-management-framework/topics/ref-raincatcher-old-and-new.adoc
+++ b/docs/workforce-management-framework/topics/ref-raincatcher-old-and-new.adoc
@@ -1,0 +1,11 @@
+[id='ref-raincatcher-new-and-old-{chapter}']
+= {WFM-RC-NameLong} 'Next' and 'Beta' Reference Information
+
+{WFM-RC-NameLong} *Beta* information can be found here<***todo***> (delete if you wish).
+
+{WFM-RC-NameLong} *Next* is the new version of the {WFM-RC-NameLong} framework.
+
+*Next* is different from *Beta* in the following ways:
+* <**todo**>
+* <**todo**>
+* <**todo**>

--- a/docs/workforce-management-framework/topics/ref-raincatcher-overview.adoc
+++ b/docs/workforce-management-framework/topics/ref-raincatcher-overview.adoc
@@ -1,0 +1,49 @@
+[id='ref-workflow-management-framework-{chapter}']
+=  Workflow Management Framework Reference Information
+
+The {WFM-RC-NameLong} Workflow Management Framework contains 3 components.
+Developers can write custom Tasks that will implement any business logic and link implementation with any UI solution.
+The Framework abstracts the developer from any web or mobile application libraries which allows developers to focus on implementing the process.
+
+.Workflow Management Framework Components
+|===
+|*Component* |*Use Case*
+
+|Task
+|Defines single unit of work for business process, that is, workflow steps
+
+|Flow
+|Contain ordered set of tasks and handlers for executing tasks in proper order
+
+|Process
+|Instance of flow containing current progress and business objects.
+|===
+
+{WFM-RC-NameLong} allows you to build production-grade Node.js and Cordova based applications from the
+following technology stack.
+
+.Application Technologies
+|===
+|TypeScript
+|Cordova
+|Node.js
+|===
+
+.{WFM-RC-NameLong} Framework goals
+The {WFM-RC-NameLong} Framework goals:
+
+* Rapid, production ready application development framework.
+* Covers Mobile, web and server side application development
+* Written in TypeScript (with support JavaScript development)
+* Secure out of the box thanks to multiple security providers (Keycloak, Passport.js)
+* Full support for offline enabled applications thanks to FeedHenry Sync
+* Extensibility provided by set of TypeScript based interfaces
+* Provide A sleek, modern, mobile enabled front-end reference applications
+* Provides abstraction layer for common application elements:
+    ** Data access
+    ** Security
+    ** Logging
+    ** Restful API creation
+    ** Unit testing
+
+The Modules abstract from any application logic and technologies allowing developers to extend it for their needs.

--- a/docs/workforce-management-framework/topics/ref-result-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-result-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-result-module-{chapter}']
+=  Result Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-sync-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-sync-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-sync-module-{chapter}']
+=  Sync Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-user-no-auth-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-user-no-auth-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-user-module-{chapter}']
+=  User (No Auth) Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-workflow-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-workflow-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-workflow-module-{chapter}']
+=  Workflow Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/topics/ref-workorder-module.adoc
+++ b/docs/workforce-management-framework/topics/ref-workorder-module.adoc
@@ -1,0 +1,6 @@
+[id='ref-workorder-module-{chapter}']
+=  Workorder Module Reference Guide
+
+(PRD-104.2)
+<**TODO**>
+Any links to the module's API or other reference material should be included in this doc.

--- a/docs/workforce-management-framework/upstream-1/introducing-the-features-of-raincatcher.adoc
+++ b/docs/workforce-management-framework/upstream-1/introducing-the-features-of-raincatcher.adoc
@@ -6,8 +6,6 @@ include::topics/shared/attributes.adoc[]
 [[introducing-raincatcher-features]]
 = Introducing {WFM-RC-NameLong} Features
 
-include::topics/con-logging.adoc[leveloffset=+1]
-
 //Not needed at time of creation
 //== Procedure
 

--- a/docs/workforce-management-framework/upstream-1/master-docinfo.xml
+++ b/docs/workforce-management-framework/upstream-1/master-docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>{DocInfoProductNumber}</productnumber>
 <subtitle>For Use with {ProductName} {ProductRelease}</subtitle>
 <abstract>
-    <para>This documentation does ABC for {ProductName} {ProductRelease}.</para>
+    <para>This {ProductName} documentation is version {ProductRelease} of the {WFM-RC-NameLong}.</para>
 </abstract>
 <authorgroup>
     <orgname>Red Hat Customer Content Services </orgname>

--- a/docs/workforce-management-framework/upstream-1/master.adoc
+++ b/docs/workforce-management-framework/upstream-1/master.adoc
@@ -28,8 +28,9 @@ include::introducing-the-features-of-raincatcher.adoc[leveloffset=+2]
 [[troubleshooting-a-raincatcher-project]]
 == Troubleshooting a {WFM-RC-NameShort} Project
 
-[[raincatcher-modules-reference]]
-== {WFM-RC-NameShort} Modules Reference
+[[raincatcher-support-modules]]
+== {WFM-RC-NameShort} Supported Modules
+include::raincatcher-supported-modules-in-detail.adoc[leveloffset=+2]
 
 [[raincatcher-appendix]]
 == {WFM-RC-NameShort} Appendix

--- a/docs/workforce-management-framework/upstream-1/master.adoc
+++ b/docs/workforce-management-framework/upstream-1/master.adoc
@@ -10,6 +10,7 @@ include::topics/shared/attributes.adoc[]
 
 [[introducing-raincatcher]]
 == Introducing {WFM-RC-NameLong}
+include::understanding-raincatcher.adoc[leveloffset=+2]
 include::introducing-the-features-of-raincatcher.adoc[leveloffset=+2]
 
 [[preparing-the-local-development-environment]]
@@ -20,7 +21,6 @@ include::introducing-the-features-of-raincatcher.adoc[leveloffset=+2]
 
 [[programming-a-raincatcher-project]]
 == Programming a {WFM-RC-NameShort} Project
-include::using-wfm-logger-and-setting-a-logging-level.adoc[leveloffset=+2]
 
 [[testing-a-raincatcher-project]]
 == Testing a {WFM-RC-NameShort} Project
@@ -31,9 +31,19 @@ include::using-wfm-logger-and-setting-a-logging-level.adoc[leveloffset=+2]
 [[raincatcher-modules-reference]]
 == {WFM-RC-NameShort} Modules Reference
 
+[[raincatcher-appendix]]
+== {WFM-RC-NameShort} Appendix
+include::raincatcher-reference-material.adoc[leveloffset=+2]
+
 // **********************************
 // * Appendix: Revision Information *
 // **********************************
 include::topics/shared/templates/revision-info.adoc[]
 
 image::./topics/shared/images/raincatcher.svg[logo]
+
+// **********************************
+// * EXAMPLE - uncomment below to see
+// * render this example 
+// **********************************
+//include::using-raincatcher-logger-and-setting-a-logging-level.adoc[leveloffset=+2]

--- a/docs/workforce-management-framework/upstream-1/raincatcher-reference-material.adoc
+++ b/docs/workforce-management-framework/upstream-1/raincatcher-reference-material.adoc
@@ -1,0 +1,15 @@
+include::topics/shared/attributes.adoc[]
+
+//':chapter:' is a vital parameter. See: http://asciidoctor.org/docs/user-manual/#include-multiple
+:chapter: raincatcher-reference-material
+
+[[raincatcher-reference-material]]
+= {WFM-RC-NameLong} Reference Material
+
+include::topics/ref-raincatcher-overview.adoc[leveloffset=+1]
+
+include::topics/ref-raincatcher-old-and-new.adoc[leveloffset=+1]
+
+include::topics/ref-raincatcher-demo.adoc[leveloffset=+1]
+
+include::topics/ref-module-structures-and-relationships.adoc[leveloffset=+1]

--- a/docs/workforce-management-framework/upstream-1/raincatcher-supported-modules-in-detail.adoc
+++ b/docs/workforce-management-framework/upstream-1/raincatcher-supported-modules-in-detail.adoc
@@ -1,0 +1,30 @@
+include::topics/shared/attributes.adoc[]
+
+//':chapter:' is a vital parameter. See: http://asciidoctor.org/docs/user-manual/#include-multiple
+:chapter: raincatcher-supported-modules-in-detail
+
+[[detailing-of-the-raincatcher-modules]]
+= Detailing of the {WFM-RC-NameLong} Modules
+
+include::topics/con-auth-demo-module.adoc[leveloffset=+1]
+include::topics/con-auth-keycloak-module.adoc[leveloffset=+1]
+include::topics/con-mongoose-module.adoc[leveloffset=+1]
+include::topics/con-result-module.adoc[leveloffset=+1]
+include::topics/con-sync-module.adoc[leveloffset=+1]
+include::topics/con-user-no-auth-module.adoc[leveloffset=+1]
+include::topics/con-workflow-module.adoc[leveloffset=+1]
+include::topics/con-workorder-module.adoc[leveloffset=+1]
+
+//Not needed at time of creation
+//== Procedure
+
+= Reference Material including APIs
+
+include::topics/ref-auth-demo-module.adoc[leveloffset=+1]
+include::topics/ref-auth-keycloak-module.adoc[leveloffset=+1]
+include::topics/ref-mongoose-module.adoc[leveloffset=+1]
+include::topics/ref-result-module.adoc[leveloffset=+1]
+include::topics/ref-sync-module.adoc[leveloffset=+1]
+include::topics/ref-user-no-auth-module.adoc[leveloffset=+1]
+include::topics/ref-workflow-module.adoc[leveloffset=+1]
+include::topics/ref-workorder-module.adoc[leveloffset=+1]

--- a/docs/workforce-management-framework/upstream-1/understanding-raincatcher.adoc
+++ b/docs/workforce-management-framework/upstream-1/understanding-raincatcher.adoc
@@ -1,0 +1,22 @@
+include::topics/shared/attributes.adoc[]
+
+//':chapter:' is a vital parameter. See: http://asciidoctor.org/docs/user-manual/#include-multiple
+:chapter: understanding-raincatcher
+
+[[understanding-raincatcher]]
+= Understanding {WFM-RC-NameLong}
+
+include::topics/con-raincatcher-overview.adoc[leveloffset=+1]
+
+include::topics/con-raincatcher-old-and-new.adoc[leveloffset=+1]
+
+include::topics/con-raincatcher-demo.adoc[leveloffset=+1]
+
+include::topics/con-module-structures-and-relationships.adoc[leveloffset=+1]
+
+//Not needed at time of creation
+//== Procedure
+
+//Not needed at time of creation
+//== Related Information
+

--- a/docs/workforce-management-framework/upstream-1/using-raincatcher-logger-and-setting-a-logging-level.adoc
+++ b/docs/workforce-management-framework/upstream-1/using-raincatcher-logger-and-setting-a-logging-level.adoc
@@ -1,9 +1,9 @@
 include::topics/shared/attributes.adoc[]
 
 //':chapter:' is a vital parameter. See: http://asciidoctor.org/docs/user-manual/#include-multiple
-:chapter: using-wfm-logger-and-setting-a-logging-level
+:chapter: using-raincatcher-logger-and-setting-a-logging-level
 
-[[using-wfm-logger-and-setting-a-logging-level]]
+[[using-raincatcher-logger-and-setting-a-logging-level]]
 = Using {WFM-RC-NameLong} Logger and Setting a Logging Level
 
 include::topics/con-logging.adoc[leveloffset=+1]


### PR DESCRIPTION
My updates based on RAINCATCH-1118 work by @austincunningham 
(I almost lost this work this morning when attempting to work from fork of RAINCATCH-1118 hence new PR RAINCATCH-1118v1)

Changes made:
1) ref adocs which were not being used now being used
2) I added in a place holder for Wojtek's comment "As an user I want to see differences between Raincatcher Next and Raincatcher Beta"
3) Restructured the work Austin *AFTER* commits:
 A) https://github.com/feedhenry-raincatcher/raincatcher-docs/commit/27632ec
 B) https://github.com/feedhenry-raincatcher/raincatcher-docs/commit/ca1a1a5
4) I commented out the include for the Logger example (in the master.adoc) so it will not appear anymore
5) IMPORTANT - I MADE CHANGES TO LOGGER ADOCS, CAN BE COMPLETELY IGNORED!!!