### PR TITLE
RAINCATCH-1234 Support modules list [WIP]

### DIFF
--- a/docs/workforce-management-framework/topics/con-supported-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-supported-modules.adoc
@@ -1,0 +1,5 @@
+= {WFM-RC-NameLong} Supported Modules
+
+An uptodate list of supported modules can be found at https://www.npmjs.com/org/raincatcher/
+
+-

--- a/docs/workforce-management-framework/topics/con-supported-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-supported-modules.adoc
@@ -1,5 +1,21 @@
 = {WFM-RC-NameLong} Supported Modules
 
-An uptodate list of supported modules can be found at https://www.npmjs.com/org/raincatcher/
+An up to date list of supported modules can be found at https://www.npmjs.com/org/raincatcher/
 
--
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/example-base]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/express-auth]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/logger]
+- link:../../../api/{WFM-RC-Api-Version}/auth-passport/docs/index.html[@raincatcher/auth-passport]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth-keycloak]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth-passport]
+- link:../../../api/{WFM-RC-Api-Version}/datasync-cloud/docs/index.html[@raincatcher/datasync-cloud]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/step-signature]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth]
+- link:../../../api/{WFM-RC-Api-Version}/datasync-client/docs/index.html[@raincatcher/datasync-client]
+- link:../../../api/{WFM-RC-Api-Version}/wfm/docs/index.html[@raincatcher/wfm]
+- link:../../../api/{WFM-RC-Api-Version}/wfm-rest-api/docs/index.html[@raincatcher/wfm-rest-api]
+- link:../../../api/{WFM-RC-Api-Version}/wfm-user/docs/index.html[@raincatcher/wfm-user]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/wfm-demo-data]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-http]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-workorder]
+- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-workflow]

--- a/docs/workforce-management-framework/topics/con-supported-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-supported-modules.adoc
@@ -1,12 +1,27 @@
 = {WFM-RC-NameLong} Supported Modules
 
-An up to date list of modules can be found at https://www.npmjs.com/org/raincatcher/. The supported list is below
+An up to date list of modules can be found at https://www.npmjs.com/org/raincatcher/. The core list 
 
-- link:../../../api/{WFM-RC-Api-Version}/express-auth/docs/index.html[@raincatcher/express-auth]
-- link:../../../api/{WFM-RC-Api-Version}/auth-passport/docs/index.html[@raincatcher/auth-passport]
-- link:../../../api/{WFM-RC-Api-Version}/datasync-cloud/docs/index.html[@raincatcher/datasync-cloud]
-- link:../../../api/{WFM-RC-Api-Version}/datasync-client/docs/index.html[@raincatcher/datasync-client]
-- link:../../../api/{WFM-RC-Api-Version}/wfm/docs/index.html[@raincatcher/wfm]
-- link:../../../api/{WFM-RC-Api-Version}/wfm-rest-api/docs/index.html[@raincatcher/wfm-rest-api]
-- link:../../../api/{WFM-RC-Api-Version}/wfm-user/docs/index.html[@raincatcher/wfm-user]
-- link:../../../api/{WFM-RC-Api-Version}/wfm-demo-data/docs/index.html[@raincatcher/wfm-demo-data]
+== link:../../../api/{WFM-RC-Api-Version}/express-auth/docs/index.html[@raincatcher/express-auth]
+The {WFM-RC-NameShort} security interface used to apply authentication and authorisation, used in conjunction whatever security provider you choose.
+
+== link:../../../api/{WFM-RC-Api-Version}/auth-passport/docs/index.html[@raincatcher/auth-passport]
+The {WFM-RC-NameShort} implementaion of Pasport.js and is the default security module for mobile and portal application.
+
+== link:../../../api/{WFM-RC-Api-Version}/datasync-cloud/docs/index.html[@raincatcher/datasync-cloud]
+The {WFM-RC-NameShort} cloud implemention of fh-sync used in conjunction with @raincatcher/datasync-client, used to sync data between cloud and mobile applications.
+
+== link:../../../api/{WFM-RC-Api-Version}/datasync-client/docs/index.html[@raincatcher/datasync-client]
+The {WFM-RC-NameShort} client implemnetion of fh-sync used in conjunction with @raincathcer/datasync-cloud , used to sync data between cloud and mobile application.
+
+== link:../../../api/{WFM-RC-Api-Version}/wfm/docs/index.html[@raincatcher/wfm]
+The {WFM-RC-NameShort} Work Flow Management module which allows developers to map a business process into an organised set of tasks to suit business needs.
+
+== link:../../../api/{WFM-RC-Api-Version}/wfm-rest-api/docs/index.html[@raincatcher/wfm-rest-api]
+The {WFM-RC-NameShort} Work Flow Management API module exposes express API endpoints for Work Flow Management Objects. 
+
+== link:../../../api/{WFM-RC-Api-Version}/wfm-user/docs/index.html[@raincatcher/wfm-user]
+The {WFM-RC-NameShort} Work Flow Management module used for user operations.
+
+== link:../../../api/{WFM-RC-Api-Version}/wfm-demo-data/docs/index.html[@raincatcher/wfm-demo-data]
+This is a sample module containing static data definitions to seed an example {WFM-RC-NameShort} demo project.

--- a/docs/workforce-management-framework/topics/con-supported-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-supported-modules.adoc
@@ -1,21 +1,12 @@
 = {WFM-RC-NameLong} Supported Modules
 
-An up to date list of supported modules can be found at https://www.npmjs.com/org/raincatcher/
+An up to date list of modules can be found at https://www.npmjs.com/org/raincatcher/. The supported list is below
 
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/example-base]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/express-auth]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/logger]
+- link:../../../api/{WFM-RC-Api-Version}/express-auth/docs/index.html[@raincatcher/express-auth]
 - link:../../../api/{WFM-RC-Api-Version}/auth-passport/docs/index.html[@raincatcher/auth-passport]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth-keycloak]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth-passport]
 - link:../../../api/{WFM-RC-Api-Version}/datasync-cloud/docs/index.html[@raincatcher/datasync-cloud]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/step-signature]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-auth]
 - link:../../../api/{WFM-RC-Api-Version}/datasync-client/docs/index.html[@raincatcher/datasync-client]
 - link:../../../api/{WFM-RC-Api-Version}/wfm/docs/index.html[@raincatcher/wfm]
 - link:../../../api/{WFM-RC-Api-Version}/wfm-rest-api/docs/index.html[@raincatcher/wfm-rest-api]
 - link:../../../api/{WFM-RC-Api-Version}/wfm-user/docs/index.html[@raincatcher/wfm-user]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/wfm-demo-data]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-http]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-workorder]
-- link:../../../api/{WFM-RC-Api-Version}[@raincatcher/angularjs-workflow]
+- link:../../../api/{WFM-RC-Api-Version}/wfm-demo-data/docs/index.html[@raincatcher/wfm-demo-data]

--- a/docs/workforce-management-framework/topics/con-supported-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-supported-modules.adoc
@@ -21,7 +21,7 @@ The {WFM-RC-NameShort} Work Flow Management module which allows developers to ma
 The {WFM-RC-NameShort} Work Flow Management API module exposes express API endpoints for Work Flow Management Objects. 
 
 == link:../../../api/{WFM-RC-Api-Version}/wfm-user/docs/index.html[@raincatcher/wfm-user]
-The {WFM-RC-NameShort} Work Flow Management module used for user operations.
+The {WFM-RC-NameShort} Aggregates all user operations for WFM modules
 
 == link:../../../api/{WFM-RC-Api-Version}/wfm-demo-data/docs/index.html[@raincatcher/wfm-demo-data]
 This is a sample module containing static data definitions to seed an example {WFM-RC-NameShort} demo project.


### PR DESCRIPTION
## Motivation:
Add a list of the supported modules to the documentation, 

## What:
list long term supported modules from Raincatcher-Core and link to API docs
Use
```
lerna ls
@raincatcher/express-auth    v0.0.1
@raincatcher/datasync-cloud  v0.0.3
@raincatcher/auth-passport   v0.0.1
@raincatcher/wfm-demo-data   v0.0.4
@raincatcher/wfm-rest-api    v0.0.4
@raincatcher/wfm-user        v0.0.4
@raincatcher/datasync-client v0.0.4
@raincatcher/wfm             v0.0.4
@raincatcher/logger          v0.0.1
@raincatcher/demo-server     v0.0.4 (private)
``` 
Excluding `@raincathcer/logger` ( as not included in the API docs) and `@raincatcher/demo-server` (Private package) 

- [ ] Documentation

## Additional Note:

Need to run typedoc to update API docs as `express-auth` and `wfm-demo-data` don't exist in the API docs. 
