### PR TITLE
Fixed logger links to point to common

### DIFF
--- a/docs/workforce-management-framework/topics/con-logging.adoc
+++ b/docs/workforce-management-framework/topics/con-logging.adoc
@@ -5,7 +5,7 @@
 *{PROJECT_NAME} Logging* is contained in the `{PROJECT_NAME}-core` module.
 
 Developers can use their own loggers by wrapping their implementation into the provided _logger interfaces_.
-For more information about the _logger interface_ structure, see link:{WFM-RC-CoreURL}{WFM-RC-Branch}/cloud/logger/src/Logger.ts[Logger.ts]
+For more information about the _logger interface_ structure, see link:{WFM-RC-CoreURL}{WFM-RC-Branch}/common/logger/src/Logger.ts[Logger.ts]
 
 The *{PROJECT_NAME}* demo application contains two implementations of the _logger interface_ and are found in the `{PROJECT_NAME}-core` module.
-To see a logging example, see the link:{WFM-RC-CoreURL}{WFM-RC-Branch}/cloud/logger/example/index.ts[Cloud Logger example].
+To see a logging example, see the link:{WFM-RC-CoreURL}{WFM-RC-Branch}/common/logger/example/index.ts[Cloud Logger example].


### PR DESCRIPTION
## Motivation:
links to logger files are not found

## What
Point the links to the correct location in the core/common directory

- [x] Documentation