### PR TITLE
change datasync-client link

### DIFF
--- a/docs/workforce-management-framework/topics/con-datasync-module.adoc
+++ b/docs/workforce-management-framework/topics/con-datasync-module.adoc
@@ -1,7 +1,7 @@
 [id='{context}-con-datasync-module']
 = Introducing the {PROJECT_NAME} Datasync Module
 
-The *{PROJECT_NAME} Datasync* Module is an implementation of the *{PROJECT_NAME}* Sync Framework.
+The *{PROJECT_NAME} Datasync* Module is an implementation of the *{ProductShortName}* Sync Framework.
 *Datasync* is made up of two applications, the xref:{context}-datasync-cloud-app[Cloud App] and the xref:{context}-datasync-client-app[Client App].
 The _Cloud App_ is implemented in the *Datasync* cloud module and the _Client App_ is implemented in the *Datasync* client module.
 The primary function of *Datasync* is to synchronize data, for example, a _workorder_, between the _Client Apps_ (mobile) and the _Cloud App_ (running on a backend server).
@@ -33,4 +33,4 @@ The _Data Synchonization Library_ can be used for offline storage of the _Client
 
 For instructions on how to implement the *Datasync Client App*, see the *Datasync Client App* link:{WFM-RC-CoreURL}{WFM-RC-Branch}/client/datasync-client/README.md[README.MD]
 
-To view an example, see the *Datasync Client App* link:{WFM-RC-CoreUrl}{WFM-RC-Branch}/cloud/datasync/example/index.ts[example].
+To view an example, see the *Datasync Client App* link:{WFM-RC-CoreUrl}{WFM-RC-Branch}/client/datasync-client/example/index.ts[example].


### PR DESCRIPTION
## Motivation:
example in datasync-client is pointing at cloud example this is misleading 

## What
point link at the datasync-client example.

- [x] Documentation