### PR TITLE
Comment empty file pro-configuring-logger.adoc from render

### DIFF
--- a/docs/workforce-management-framework/upstream-1/working-with-everything.adoc
+++ b/docs/workforce-management-framework/upstream-1/working-with-everything.adoc
@@ -21,7 +21,7 @@ include::topics/con-workflow-step.adoc[leveloffset=+1]
 
 == Procedures
 // Procedures
-include::topics/pro-configuring-logging.adoc[leveloffset=+1]
+//include::topics/pro-configuring-logging.adoc[leveloffset=+1]
 include::topics/pro-keycloak-enablement.adoc[leveloffset=+1]
 include::topics/pro-keycloak-implementation.adoc[leveloffset=+1]
 include::topics/pro-passportauth-pointing-to-a-datasource.adoc[leveloffset=+1]


### PR DESCRIPTION
## Motivation:
pro-configuring-logger.adoc is an empty file with just headers , remove to improve render

## What:
comment the include statement for pro-configuring-logger.adoc

- [ ] Documentation