### PR TITLE
[RAINCATCH-1302] Review passport-auth docs

### DIFF
--- a/docs/shared/attributes.adoc
+++ b/docs/shared/attributes.adoc
@@ -26,10 +26,11 @@
 :Keycloak: Keycloak
 //api url
 :WFM-RC-Api-Version: 1.0.0
-:WFM-RC-Api-Default-Strategy: /auth-passport/docs/modules/_src_auth_defaultstrategy_.html
-:WFM-RC-Api-Passport-Auth: /auth-passport/docs/classes/_src_auth_passportauth_.passportauth.html#setup
+:WFM-RC-Api-Default-Strategies: /auth-passport/docs/modules/_src_auth_defaultstrategies_.html
+:WFM-RC-Api-Passport-Auth: /auth-passport/docs/classes/_src_auth_passportauth_.passportauth.html
 :WFM-RC-Api-User-Repository: /auth-passport/docs/interfaces/_src_user_userrepository_.userrepository.html
-:WFM-RC-Api-Endpoint-Security: /auth-passport/docs/interfaces/_src_auth_passportauth_.endpointsecurity.html
+:WFM-RC-Api-User-Service: /auth-passport/docs/interfaces/_src_user_userservice_.userservice.html
+:WFM-RC-Api-Endpoint-Security: /express-auth/docs/interfaces/_src_endpointsecurity_.endpointsecurity.html
 
 // git url
 :WFM-RC-images: https://raw.githubusercontent.com/feedhenry-raincatcher/raincatcher-docs/master/docs/shared/images/

--- a/docs/workforce-management-framework/topics/con-introducing-securityfeatures.adoc
+++ b/docs/workforce-management-framework/topics/con-introducing-securityfeatures.adoc
@@ -13,11 +13,11 @@ If you build a custom security implementation, the endpoints are secured in the 
 
 If you choose to build a custom security implementation, you will need to:
 
- . Import the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}[EndpointSecurity] interface from *Passport.js*
+ . Import the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Endpoint-Security}[EndpointSecurity] interface from *Passport.js*
  . Implement the interface in the custom security implementation
  . Use the _protect_ method to guard routes (the security permissions being role based)
 
-NOTE: All link:https://expressjs.com/[express] routes outside of {PROJECT_NAME} modules must implement the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}[EndpointSecurity] Security Interface.
+NOTE: All link:https://expressjs.com/[express] routes outside of {PROJECT_NAME} modules must implement the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Endpoint-Security}[EndpointSecurity] Security Interface.
 
 == Introducing Passport.js
 

--- a/docs/workforce-management-framework/topics/con-passportauth-module.adoc
+++ b/docs/workforce-management-framework/topics/con-passportauth-module.adoc
@@ -5,10 +5,10 @@ The *{PROJECT_NAME} link:{WFM-RC-CoreTreeURL}{WFM-RC-Branch}/cloud/passportauth[
 It is the default authentication and authorization module for *{PROJECT_NAME}*.
 
 *PassportAuth* provides plugable authentication using link:http://passportjs.org/docs/configure[strategies].
-*PassportAuth* offers a comprehensive set of strategies that support authentication using a username and password, Facebook logon, Twitter logon, and more.
+*Passport.js* offers a comprehensive set of strategies that support authentication using a username and password, Facebook logon, Twitter logon, and more.
 
 *PassportAuth* provides:
 
 * Access Control of Express routes
-* Authentication using the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Default-Strategy}[default strategy]
+* Authentication using the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Default-Strategies}[default strategies]
 * Express session middleware using link:https://github.com/expressjs/session[express-session]

--- a/docs/workforce-management-framework/topics/pro-passportauth-pointing-to-a-datasource.adoc
+++ b/docs/workforce-management-framework/topics/pro-passportauth-pointing-to-a-datasource.adoc
@@ -3,7 +3,7 @@
 
 The *PassportAuth* module is an out of the box security solution for default integration.
 *PassportAuth* uses JSON files that contain user data.
-This user data contains sample users and access roles for demo purposes in the link:{WFM-RC-CoreURL}{WFM-RC-Branch}/demo/server/src/modules/wfm-user/users.json[Demo Data].
+This user data contains sample users and access roles for demo purposes in the link:{WFM-RC-CoreURL}{WFM-RC-Branch}/demo/server/src/modules/passport-auth/users.json[Demo Data].
 This section describes how to use a different user datasource.
 
 This section includes:
@@ -45,9 +45,9 @@ Ensure you have completed:
 [id='{context}-pointing-passportauth-to-a-datasource']
 [discrete]
 == Pointing PassportAuth to a Datasource
-
 NOTE: _UserRepository_ requires user data containing a minimum of username and password to work.
 
-. Implement the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}[UserRepository].
+. Implement the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}[UserRepository Interface].
+. Implement the link:./../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Service}[UserService Interface].
 
-For an end-to-end implementation of the _UserRepository_ interface, see the link:{WFM-RC-Github-Core}{WFM-RC-Branch}{WFM-RC-PassportAuth-Example}[PassportAuth Example].
+For an end-to-end implementation of the _UserRepository_ and _UserService_ interface, see the link:{WFM-RC-Github-Core}{WFM-RC-Branch}{WFM-RC-PassportAuth-Example}[PassportAuth Example].

--- a/docs/workforce-management-framework/topics/ref-passportauth-securitystrategy.adoc
+++ b/docs/workforce-management-framework/topics/ref-passportauth-securitystrategy.adoc
@@ -30,38 +30,46 @@ app.get('/testAdminEndpoint', authService.protect('admin'), (req: express.Reques
 });
 ----
 
-NOTE: Demo roles are defined in link:{WFM-RC-CoreURL}{WFM-RC-Branch}/demo/server/src/modules/wfm-user/users.json[user.json].
+NOTE: Demo roles are defined in link:{WFM-RC-CoreURL}{WFM-RC-Branch}/demo/server/src/modules/passport-auth/users.json[users.json].
 
 [id='{context}-defining-passportauth-password-storage']
 == Defining PassportAuth Password Storage
-The *PassportAuth* user data is stored in link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}#getuserbylogin[User Repository Interface].
-Make sure that the _User Repository Interface_ is implemented in order to point *PassportAuth* to a datasource.
+The *PassportAuth* user data is stored in a _User Repository_. Make sure that the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-User-Repository}#getuserbylogin[User Repository Interface]
+is implemented in order to point *PassportAuth* to a datasource.
 
 [id='{context}-passportauth-authentication']
 == PassportAuth Authentication
 {PROJECT_NAME} authentication is handled by the cloud server using users unique username and password combination.
-The *PassportAuth* service is a default authentication strategy as based on the local *Passport.js* implementation.
+The *PassportAuth* service is a default authentication strategy as based on the *Passport.js* local and JWT implementation.
 
-*PassportAuth* uses link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Endpoint-Security}#authenticate[authenticate]
+*PassportAuth* uses link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}#authenticate[authenticate]
 middleware for cookie based authentication.To access _express_ routes,
 a user must login using their credentials. A cookie containing a user session key is used to authenticate and
 authorize a user who is requesting a server endpoint.
 
-NOTE: In the demonstration application, the login post route has an authenticate() method that checks user credentials
-against the stored credentials in the _user.json_ file. It also checks the user's role against the role on _user.json_.
+NOTE: In the demonstration application, the cookie login post route has an authenticate() method that checks user credentials
+against the stored credentials in the _users.json_ file. It also checks the user's role against the role on _users.json_.
+
+*PassportAuth* uses link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}#authenticateWithToken[authenticateWithToken]
+for token based authentication. To access _express_ routes, a user must login using their credentials. A generated JSON web token (JWT)
+and the user's profile is sent to the client upon successful authentication.
+
+NOTE: The JWT token needs to be included in each subsequent requests after a successful login as part of the *Authorization* header
 
 For more information, see the link:{WFM-RC-Github-Core}{WFM-RC-Branch}{WFM-RC-PassportAuth-Example}[PassportAuth example].
 
 [id='{context}-passportauth-authorization']
 == PassportAuth Authorization
-Authorization is supported by link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Endpoint-Security}[protect middleware] that validates a _user session id_ against session.
+Authorization is supported by link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Endpoint-Security}[protect middleware] that validates a session or a JWT token depending on 
+the *Passport.js* strategy used and checks if the user has the required role.
 
 [id='{context}-customizing-a-strategy']
 == Customizing a Strategy
-The link:default strategy for the *PassportAuth* module implements the *Passport.js* local strategy.
-To use a different security strategy that is supported by {PROJECT_NAME}, override the
-link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}[PassportAuth.setup] method.
+The default strategies for the *PassportAuth* module implements the *Passport.js* local and JWT strategy. 
+To customize the existing strategies, override the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}#setupCookie[PassportAuth.setupCookie] or
+link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}#setupToken[PassportAuth.setupToken] method.
+To use a different security strategy that is supported by *Passport.js*, override the link:../../../api/{WFM-RC-Api-Version}{WFM-RC-Api-Passport-Auth}#init[PassportAuth.init] method.
 
 [id='{context}-passportAuth-demo-users-and-access-roles']
 == PassportAuth Demo Users and Access Roles
-*PassportAuth* is by default integrated with the Demo application and contains sample users and access roles which are defined in the link:https://github.com/feedhenry-raincatcher/raincatcher-core/blob/{WFM-RC-Branch}/demo/server/src/modules/wfm-user/users.json[Demo Data] JSON file.
+*PassportAuth* is by default integrated with the Demo application and contains sample users and access roles which are defined in the link:{WFM-RC-CoreURL}{WFM-RC-Branch}/demo/server/src/modules/passport-auth/users.json[demo data] JSON file.


### PR DESCRIPTION
## Description
Review passport auth related documentation. Include in changes from
[RAINCATCH-1276](https://issues.jboss.org/browse/RAINCATCH-1276) which involved adding in documentation for JWT strategy. 

## Progress
- [x] Review PassportAuth docs
- [x] Include documentation for JWT

## Additional Notes
- Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1302
- JWT Doc Ticket - https://issues.jboss.org/browse/RAINCATCH-1276