### PR TITLE
Quickstart

### DIFF
--- a/docs/workforce-management-framework/topics/ref-quickstart.adoc
+++ b/docs/workforce-management-framework/topics/ref-quickstart.adoc
@@ -1,0 +1,44 @@
+[id='{context}-ref-raincatcher-quickstart']
+= RainCatcher QuickStart
+
+== Requirements
+
+- Node.js
+- MongoDB
+- Redis
+
+== Getting started.
+
+1. Clone all required repositories
+
+[source,bash]
+----
+git clone git@github.com:feedhenry-raincatcher/raincatcher-mobile.git
+git clone git@github.com:feedhenry-raincatcher/raincatcher-portal.git
+git clone git@github.com:feedhenry-raincatcher/raincatcher-server.git
+----
+
+2. Install all required dependencies for each project
+
+[source,bash]
+----
+npm install
+----
+
+3. Install yeoman and rcstep generator
+
+[source,bash]
+----
+npm install -g yo
+npm install -g generator-rcstep
+----
+
+4. Create step
+
+[source,bash]
+----
+yo rcstep
+---
+
+
+


### PR DESCRIPTION
## Motivation

Provide essence of the RainCatcher to guide developer in 10 minutes thru all functionalities.

Tried 2 options
- Include existing content in quickstart
- Duplicate content as bellow.

I personally thing that none of them work.
Duplication seems to be not an option as I will need to include exactly the same content. 
Including it's duplicating content in the overall documentation which is little bit confusing for people where they should get that. 

We have now getting started and step documentation that covers that case.
I wanted to get your opinions.
