### PR TITLE
[RAINCATCH-1323] start:ts

### DIFF
--- a/docs/workforce-management-framework/topics/con-release-notes.adoc
+++ b/docs/workforce-management-framework/topics/con-release-notes.adoc
@@ -5,19 +5,26 @@
 {PROJECT_NAME} connects a business back-office portal application with its fleet of mobilized employees via a mobile application.
 Both mobile and portal applications are fully customizable.
 
-== About {WFM-RC-Version} Release
-{PROJECT_NAME} {WFM-RC-Version} is a new produce was previously in tech preview. The Features are listed below.
+== 1.1.0 Release
+
+=== Starting the applications
+The `npm run start` command now runs the compiled JavaScript code as opposed to utilizing link:https://github.com/TypeStrong/ts-node[TypeScript Node] to run everything from the TypeScript sources.
+
+The previous behavior is still achievable via `npm run start:ts`.
+
+== 1.0.0 Release
+{PROJECT_NAME} 1.0.0 is a new product that was previously in tech preview. The Features are listed below.
 
 === Workflows
-The ability to create customizable processes (called workflows). Workflows are made up of steps which can be the packaged steps
-or can be custom steps developed for a particular use case.
+The ability to create customizable processes (called Workflows). Workflows are made up of Steps which can be the Packaged Steps
+or can be custom Steps developed for a particular use case.
 
 === Workorders
-The ability to process instances called workorders. Workorder are a instance of a individual workflow.
-Workorder can be assigned via the portal to individual employees as a job for completion.
+The ability to process instances called Workorders. Workorders are a instance of an individual workflow.
+Workorder can be assigned via the Portal Application to individual employees as a job for completion.
 
 === Step Generator
-Generates a step via cli, the step can be customized to meet a use case.
+Generates a Step via a CLI, the step can be customized to meet a use case.
 
 === Packaged Step
-Providing predefined signature step that can be used for any business needs.
+Providing predefined signature Step that can be used for any business needs.

--- a/docs/workforce-management-framework/topics/pro-contribute-guide.adoc
+++ b/docs/workforce-management-framework/topics/pro-contribute-guide.adoc
@@ -62,8 +62,18 @@ NOTE: The Core repository is automatically cloned by the command `npm run bootst
 [discrete]
 == Starting the Core Server
 
+The following line runs the server application and the internal dependencies from their TypeScript sources:
+
 [source,bash]
 ----
+npm run start:ts
+----
+
+To compile and run from JavaScript:
+
+[source,bash]
+----
+npm run build
 npm run start
 ----
 

--- a/docs/workforce-management-framework/topics/pro-running-the-demo-repositories.adoc
+++ b/docs/workforce-management-framework/topics/pro-running-the-demo-repositories.adoc
@@ -61,7 +61,7 @@ For each repository previously cloned, run `npm install` so regular NPM dependen
 [source,bash]
 ----
 cd raincatcher-server/
-npm run start
+npm run start:ts
 ----
 
 NOTE: The terminal is out of use while the Core Server is running.

--- a/docs/workforce-management-framework/topics/ref-server.adoc
+++ b/docs/workforce-management-framework/topics/ref-server.adoc
@@ -21,16 +21,16 @@ https://github.com/feedhenry-{PROJECT_NAME}/{PROJECT_NAME}-core/blob/master/demo
 
 == Server-side Application Development Guide
 
-To launch the Cloud Application, execute `npm run start`.
+To launch the Cloud Application, execute `npm run start:ts`, this runs the Server Application from its TypeScript sources.
 
 To start debugging, execute `npm run startDebug`.
 
 NOTE: Both commands use a tool called `ts-node` and this runs a process without compiling Typescript source code.
 
-To run the code using Node.js, ensure you compile the code first:
+To run the code using Node.JS, ensure you compile the code first:
 
  * `npm run build`
- * `node src/index.js`
+ * `npm run start`
 
 When compiling source code, the `ts-node` command uses compiled Javascript files. To clean compiled Javascript files, execute `npm run clean`
 


### PR DESCRIPTION
Companion PR for https://github.com/feedhenry-raincatcher/raincatcher-core/pull/151, adding information on the addition of the `npm run start:ts` command and change to `npm run start`.