### PR TITLE
Topic/doc workflow intro

### DIFF
--- a/docs/workforce-management-framework/topics/pro-running-the-demo-repositories.adoc
+++ b/docs/workforce-management-framework/topics/pro-running-the-demo-repositories.adoc
@@ -1,22 +1,21 @@
 [id='{context}-pro-running-the-demo-repositories']
 = Running the {PROJECT_NAME} Applications on a Local Machine
 
-The {PROJECT_NAME} applications in this section are dependent on the _public NPM Registry_.
-
-This allows for a simpler setup of the {PROJECT_NAME} applications for users that only require the application to run, and will not engage in development.
+Get started by running {PROJECT_NAME} applications on your local machine. Follow
+these steps and use the _public NPM Registry_ to set up the {PROJECT_NAME}
+applications that contain sample Steps, Workflows, and Workorders.
 
 [discrete]
 == Prerequisites
 
-Ensure you have:
+The following must be installed on your system:
 
-* Node and npm installed (tested on Node {WFM-RC-NodeVersion})
+* Node and npm (tested version: {WFM-RC-NodeVersion})
 * git
-* access to `git@github.com:feedhenry-raincatcher/raincatcher-server.git`
-* access to `git@github.com:feedhenry-raincatcher/raincatcher-mobile.git`
-* access to `git@github.com:feedhenry-raincatcher/raincatcher-portal.git`
 * MongoDB
 * Redis
+
+You must have access to GitHub to install the {PROJECT_NAME} applications.
 
 [id='{context}-published-repositories-cloning-the-git-repositories']
 [discrete]

--- a/docs/workforce-management-framework/topics/pro-using-the-demo-app.adoc
+++ b/docs/workforce-management-framework/topics/pro-using-the-demo-app.adoc
@@ -1,5 +1,17 @@
 [id='{context}-pro-using-the-demo-app']
-= Working with the Portal Application and Mobile Application
+= Learning to Use Workflows and Workorders
+
+{PROJECT_NAME} applications streamline process management with reusable objects
+called _Workflows_ and _Workorders_.
+
+* A _Workflow_ is a set of steps that end users follow to complete a process.
+Administrators create _Workflows_ with the Portal application.
+* A _Workorder_ is an instantiation of a _Workflow_ that contains specific details.
+Administrators can assign _Workorders_ to end users. End users access
+_Workorders_ in the Mobile application.
+
+In the following section, you can use the sample content in the {PROJECT_NAME}
+applications running on your local machine.
 
 == Working with the Portal Application
 

--- a/docs/workforce-management-framework/upstream-1/master.adoc
+++ b/docs/workforce-management-framework/upstream-1/master.adoc
@@ -12,18 +12,18 @@ include::topics/shared/attributes.adoc[]
 image::https://raw.githubusercontent.com/feedhenry-raincatcher/raincatcher-docs/master/docs/shared/images/logo-blue.png[logo]
 
 [[raincatcher]]
-= WFM Overview
+= Raincatcher Introduction
 include::topics/con-introducing-raincatcher.adoc[leveloffset=+1]
 include::topics/ref-introducing-raincatcher.adoc[leveloffset=+2]
 
 [[getting-started]]
-= Running the {PROJECT_NAME} Applications
+= Getting Started with the {PROJECT_NAME} Applications
 include::topics/pro-running-the-demo-repositories.adoc[leveloffset=+1]
 include::topics/pro-using-the-demo-app.adoc[leveloffset=+1]
 include::topics/ref-demo-app.adoc[leveloffset=+2]
 
 [[building-wfm-process]]
-= Building WFM Process in {PROJECT_NAME}
+= Building a Workflow
 include::topics/con-workflow-step.adoc[leveloffset=+1]
 include::topics/con-packaged-step.adoc[leveloffset=+1]
 
@@ -86,6 +86,3 @@ include::topics/pro-contribute-guide.adoc[leveloffset=+1]
 
 // Appendix: Revision Information
 include::topics/shared/templates/revision-info.adoc[]
-
-
-


### PR DESCRIPTION
the section for using the demo apps seems to focus on the tools rather than the task. I think the point for users is to learn how to create workflows and get familiar with workorders and steps. I've suggested a heading that focuses more on what the user will do in the section, rather than 'working with the portal application', which isn't descriptive.