### PR TITLE
fixed dead links in docs

### DIFF
--- a/docs/shared/attributes.adoc
+++ b/docs/shared/attributes.adoc
@@ -27,11 +27,11 @@
 :Keycloak: Keycloak
 //api url
 :WFM-RC-Api-Version: 1.1.0
-:WFM-RC-Api-Default-Strategies: /auth-passport/docs/modules/_src_auth_defaultstrategies_.html
-:WFM-RC-Api-Passport-Auth: /auth-passport/docs/classes/_src_auth_passportauth_.passportauth.html
-:WFM-RC-Api-User-Repository: /auth-passport/docs/interfaces/_src_user_userrepository_.userrepository.html
-:WFM-RC-Api-User-Service: /auth-passport/docs/interfaces/_src_user_userservice_.userservice.html
-:WFM-RC-Api-Endpoint-Security: /express-auth/docs/interfaces/_src_endpointsecurity_.endpointsecurity.html
+:WFM-RC-Api-Default-Strategies: /auth-passport/globals.html#defaultdeserializeuser
+:WFM-RC-Api-Passport-Auth: /auth-passport/classes/passportauth.html
+:WFM-RC-Api-User-Repository: /auth-passport/interfaces/userrepository.html
+:WFM-RC-Api-User-Service: /auth-passport/interfaces/userservice.html
+:WFM-RC-Api-Endpoint-Security: /express-auth/interfaces/endpointsecurity.html
 
 // git url
 :WFM-RC-images: /docs/images/

--- a/docs/workforce-management-framework/topics/con-angularjs-modules.adoc
+++ b/docs/workforce-management-framework/topics/con-angularjs-modules.adoc
@@ -11,7 +11,7 @@ The latest list of modules is found at link:https://www.npmjs.com/org/raincatche
 |The {PROJECT_NAME} client-side authentication module for use with a KeyCloak back-end.
 
 |link:https://github.com/feedhenry-raincatcher/raincatcher-angularjs/tree/master/packages/angularjs-auth-passport[@raincatcher/angularjs-auth-passport]
-|The {PROJECT_NAME} client-side authentication module for use with a ExpressJS + link:passport.js[http://passportjs.org/].
+|The {PROJECT_NAME} client-side authentication module for use with a ExpressJS + link:http://passportjs.org/[passport.js].
 
 |link:https://github.com/feedhenry-raincatcher/raincatcher-angularjs/tree/master/packages/angularjs-auth[@raincatcher/angularjs-auth]
 |User Interface module for use with the authentication packages linked above.

--- a/docs/workforce-management-framework/topics/con-logging.adoc
+++ b/docs/workforce-management-framework/topics/con-logging.adoc
@@ -3,7 +3,7 @@
 *{PROJECT_NAME} Logger* creates logging facade for JavaScript based applications that
 is used by all {PROJECT_NAME} modules. Developers can use custom loggers by wrapping their implementation into the provided logger interface.
 
-For more information about the _logger interface_ structure, see link:../../../api/{WFM-RC-Api-Version}/logger/docs/index.html[logger api documentation]
+For more information about the _logger interface_ structure, see link:../../../api/{WFM-RC-Api-Version}/logger/index.html[logger api documentation]
 
 The *{PROJECT_NAME}* demo application contains two implementations of the _logger interface_ a
 

--- a/docs/workforce-management-framework/topics/con-production-checklist.adoc
+++ b/docs/workforce-management-framework/topics/con-production-checklist.adoc
@@ -11,7 +11,7 @@ Application is created with 2 default profiles:
 - development (link:{WFM-RC-ServerURL}{WFM-RC-Release-Tag}/config-dev.js[config-dev.js])
 - production (link:{WFM-RC-ServerURL}{WFM-RC-Release-Tag}/config-prod.js[config-prod.js])
 
-For more information about profiles go to link:{context}-ref-server[Server side reference]
+For more information about profiles go to xref:{context}-ref-server[Server side reference]
 
 When moving to production developers should review their configuration to make sure that a
 
@@ -40,7 +40,7 @@ Mobile configuration should be adjusted before building mobile application.
 Configuration can be found link:{WFM-RC-MobileURL}{WFM-RC-Release-Tag}/src/config.json[config.json file]
 
 Developers can adjust sync options improve overall performance.
-For more information see link:con-performance-guidelines.adoc[Performance Guide]
+For more information see xref:{context}-performance-guidelines[Performance Guide]
 Additionally Keycloak configuration can be changed.
 
 Most important values


### PR DESCRIPTION
## Why?
Dead links in documentation

## What?
Following links were dead in the docs
```
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/auth-passport/docs/modules/_src_auth_defaultstrategies_.html | default strategies
-- | -- | --
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/auth-passport/docs/classes/_src_auth_passportauth_.passportauth.html | PassportAuth
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/auth-passport/docs/interfaces/_src_user_userrepository_.userrepository.html | User Repository Interface
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/auth-passport/docs/interfaces/_src_user_userservice_.userservice.html | UserService Interface
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/logger/docs/index.html | logger api documentation
404 Not Found | http://raincatcher.feedhenry.io/docs/passport.js | http://passportjs.org/
404 Not Found | http://raincatcher.feedhenry.io/docs/{context}-ref-server | Server side reference
404 Not Found | http://raincatcher.feedhenry.io/docs/con-performance-guidelines.adoc | Performance Guide
404 Not Found | http://raincatcher.feedhenry.io/api/1.1.0/express-auth/docs/interfaces/_src_endpointsecurity_.endpointsecurity.html | EndpointSecurity
```
## Repair
- [x] Documentation